### PR TITLE
fix(build): compile against stable Zig 0.16.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_mcp,
     .version = "0.0.0",
     .fingerprint = 0x1c29ab0bcd4442bc,
-    .minimum_zig_version = "0.16.0-dev.205+4c0127566",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/docs/Walk.zig
+++ b/docs/Walk.zig
@@ -791,8 +791,6 @@ fn expr(w: *Walk, scope: *Scope, parent_decl: Decl.Index, node: Ast.Node.Index) 
             try expr(w, scope, parent_decl, full.ast.template);
         },
 
-        .asm_legacy => {},
-
         .builtin_call_two,
         .builtin_call_two_comma,
         .builtin_call,


### PR DESCRIPTION
## Problem

`zig build` currently fails on every released Zig toolchain:

- `minimum_zig_version` in `build.zig.zon` is pinned to `0.16.0-dev.205+4c0127566`, a dev tarball that is no longer hosted on ziglang.org.
- `docs/Walk.zig` switches on `Ast.Node.Tag.asm_legacy`, which was removed before the 0.16.0 release. Building with stable `0.16.0` errors out:

  ```
  docs/Walk.zig:794:10: error: enum 'zig.Ast.Node.Tag' has no member named 'asm_legacy'
          .asm_legacy => {},
  ```

This is the same class of breakage as #5 / #6, just one Zig cycle later.

## Fix

1. Bump `minimum_zig_version` to the released `0.16.0`.
2. Drop the `.asm_legacy => {},` arm. The arm was a no-op, and the surrounding switch is exhaustive — keeping it is a hard compile error on any Zig that no longer carries the enum value.

## Verification

```bash
$ zig version
0.16.0
$ zig build
$ ls zig-out/main.wasm
zig-out/main.wasm
```

Built `main.wasm` exercised end-to-end via the downstream [zigpeek](https://github.com/TanGentleman/zigpeek) CLI (`search_std_lib`, `get_std_lib_item`, builtin lookups) — no behavior change.

## Notes

- I have been learning Zig, and had a really great time working on the zigpeek project built off the work in this repo! Cheers :D